### PR TITLE
Improve canvas rendering clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,15 +764,21 @@
                 }
                 
                 console.log("✅ Creating enhanced Babylon engine...");
-                const engine = new BABYLON.Engine(canvas, true, { 
+                const engine = new BABYLON.Engine(canvas, true, {
                     antialias: true,
                     powerPreference: "high-performance",
                     stencil: true,
                     preserveDrawingBuffer: true,
                     alpha: false
                 });
-                
-                engine.setHardwareScalingLevel(1.0);
+
+                const applyHardwareScaling = () => {
+                    const pixelRatio = window.devicePixelRatio || 1;
+                    const scalingLevel = Math.min(1, 1 / pixelRatio);
+                    engine.setHardwareScalingLevel(scalingLevel);
+                };
+
+                applyHardwareScaling();
                 
                 updateLoadingProgress("Creating enhanced scene...");
                 const scene = new BABYLON.Scene(engine);
@@ -1378,6 +1384,7 @@
                 // Handle window resize
                 window.addEventListener("resize", function() {
                     engine.resize();
+                    applyHardwareScaling();
                 });
                 
                 // Show the game


### PR DESCRIPTION
## Summary
- adjust the Babylon.js engine hardware scaling to respect the device pixel ratio so the canvas renders at full resolution
- reapply the scaling on window resize so high-DPI clarity persists when the viewport changes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68cb5a72adb08327898d06cb4790a099