### PR TITLE
Fix camera target update without AddToRef

### DIFF
--- a/index.html
+++ b/index.html
@@ -1056,7 +1056,8 @@
                 }
 
                 function updateCameraTarget() {
-                    BABYLON.Vector3.AddToRef(player.position, cameraTargetOffset, cameraTarget);
+                    cameraTarget.copyFrom(player.position);
+                    cameraTarget.addInPlace(cameraTargetOffset);
                     camera.setTarget(cameraTarget);
                 }
 


### PR DESCRIPTION
## Summary
- update camera target calculation to avoid using the missing Vector3.AddToRef helper
- copy the player position and offset the target vector in place before setting the camera target

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cba76deaec832799f974dfce638a29