### PR TITLE
Fix CDN module imports

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,10 +230,10 @@
 
     <script type="module">
         import * as THREE from "https://unpkg.com/three@0.160.1/build/three.module.js";
-        import { GLTFLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/GLTFLoader.js";
-        import { DRACOLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/DRACOLoader.js";
-        import { PointerLockControls } from "https://unpkg.com/three@0.160.1/examples/jsm/controls/PointerLockControls.js";
-        import { SkeletonUtils } from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js";
+        import { GLTFLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/GLTFLoader.js?module";
+        import { DRACOLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/DRACOLoader.js?module";
+        import { PointerLockControls } from "https://unpkg.com/three@0.160.1/examples/jsm/controls/PointerLockControls.js?module";
+        import { SkeletonUtils } from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js?module";
 
         THREE.Cache.enabled = true;
 


### PR DESCRIPTION
## Summary
- update Three.js example module imports to use the `?module` query so the CDN rewrites bare specifiers

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68cc0320065c8327bc21ad0d7152a321