### PR TITLE
Add resilient service worker setup

### DIFF
--- a/britannia-service-worker.js
+++ b/britannia-service-worker.js
@@ -1,0 +1,106 @@
+const CACHE_VERSION = 'britannia-precache-v1';
+const CORE_ASSETS = [
+  './',
+  './index.html',
+];
+
+const cacheCoreAssets = async () => {
+  try {
+    const cache = await caches.open(CACHE_VERSION);
+    await cache.addAll(CORE_ASSETS);
+  } catch (error) {
+    console.warn('Service worker failed to precache core assets:', error);
+  }
+};
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(cacheCoreAssets());
+  self.skipWaiting();
+});
+
+const removeOldCaches = async () => {
+  try {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys
+        .filter((key) => key !== CACHE_VERSION)
+        .map((key) => caches.delete(key))
+    );
+  } catch (error) {
+    console.warn('Service worker cache cleanup failed:', error);
+  }
+};
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(removeOldCaches());
+  self.clients.claim();
+});
+
+const shouldHandleRequest = (request) => {
+  if (request.method !== 'GET') {
+    return false;
+  }
+
+  const url = new URL(request.url);
+  return url.origin === self.location.origin;
+};
+
+const networkWithCacheFallback = async (request) => {
+  try {
+    const networkResponse = await fetch(request);
+
+    if (!networkResponse || networkResponse.status !== 200 || networkResponse.type === 'opaque') {
+      return networkResponse;
+    }
+
+    const cache = await caches.open(CACHE_VERSION);
+    cache.put(request, networkResponse.clone()).catch((error) => {
+      console.warn('Service worker failed to cache response:', error);
+    });
+
+    return networkResponse;
+  } catch (error) {
+    const cachedResponse = await caches.match(request);
+    if (cachedResponse) {
+      return cachedResponse;
+    }
+
+    if (request.mode === 'navigate') {
+      const fallback = await caches.match('./index.html');
+      if (fallback) {
+        return fallback;
+      }
+    }
+
+    return new Response('Service unavailable', {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+  }
+};
+
+self.addEventListener('fetch', (event) => {
+  if (!shouldHandleRequest(event.request)) {
+    return;
+  }
+
+  event.respondWith(
+    (async () => {
+      const cached = await caches.match(event.request);
+      if (cached) {
+        event.waitUntil(networkWithCacheFallback(event.request));
+        return cached;
+      }
+
+      return networkWithCacheFallback(event.request);
+    })().catch((error) => {
+      console.warn('Service worker fetch handler failed:', error);
+      return new Response('Service unavailable', {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: { 'Content-Type': 'text/plain' },
+      });
+    })
+  );
+});

--- a/index.html
+++ b/index.html
@@ -238,6 +238,58 @@
         THREE.Cache.enabled = true;
 
         const MODEL_BASE_URL = "https://dmaher42.github.io/Britiannia2/assets/models/web/";
+        const SERVICE_WORKER_PATH = "britannia-service-worker.js";
+
+        const setupServiceWorker = async () => {
+            if (!("serviceWorker" in navigator)) {
+                return;
+            }
+
+            const currentScope = window.location.href;
+            const isWithinScope = (registration) => currentScope.startsWith(registration.scope);
+            const getPathname = (scriptURL) => {
+                try {
+                    return new URL(scriptURL).pathname;
+                } catch (error) {
+                    console.warn("Unable to parse service worker script URL:", scriptURL, error);
+                    return "";
+                }
+            };
+            const isCurrentScript = (scriptURL) => getPathname(scriptURL).endsWith(`/${SERVICE_WORKER_PATH}`);
+
+            try {
+                const registrations = await navigator.serviceWorker.getRegistrations();
+                const legacyRegistrations = registrations.filter((registration) => {
+                    if (!isWithinScope(registration)) {
+                        return false;
+                    }
+
+                    const scriptURLs = [
+                        registration.active?.scriptURL,
+                        registration.waiting?.scriptURL,
+                        registration.installing?.scriptURL
+                    ].filter(Boolean);
+
+                    if (scriptURLs.length === 0) {
+                        return false;
+                    }
+
+                    return scriptURLs.every((url) => !isCurrentScript(url));
+                });
+
+                await Promise.all(
+                    legacyRegistrations.map((registration) =>
+                        registration.unregister().catch(() => false)
+                    )
+                );
+
+                await navigator.serviceWorker.register(SERVICE_WORKER_PATH, { scope: "./" });
+            } catch (error) {
+                console.warn("Service worker setup failed:", error);
+            }
+        };
+
+        setupServiceWorker();
 
         const REGION_DEFINITIONS = [
             {


### PR DESCRIPTION
## Summary
- add a dedicated service worker that precaches the shell, caches same-origin GET requests, and returns a clean fallback on network failures
- register the new worker from the main module while uninstalling the legacy worker that caused runtime crashes

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68cc6e38cbc48327bd77f360c0114950