### PR TITLE
Fix SkeletonUtils import syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,7 +233,7 @@
         import { GLTFLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/GLTFLoader.js?module";
         import { DRACOLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/DRACOLoader.js?module";
         import { PointerLockControls } from "https://unpkg.com/three@0.160.1/examples/jsm/controls/PointerLockControls.js?module";
-        import { SkeletonUtils } from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js?module";
+        import * as SkeletonUtils from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js?module";
 
         THREE.Cache.enabled = true;
 


### PR DESCRIPTION
## Summary
- switch the SkeletonUtils import to use namespace syntax so clone and other helpers work

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ccfb51cb2c83278a9da1d2350a8184