### PR TITLE
Fix module specifiers for three.js addons

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,11 +229,11 @@
     <div id="interactionPrompt">Press <span>E</span> to inspect</div>
 
     <script type="module">
-        import * as THREE from "https://unpkg.com/three@0.160.1/build/three.module.js";
-        import { GLTFLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/GLTFLoader.js";
-        import { DRACOLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/DRACOLoader.js";
-        import { PointerLockControls } from "https://unpkg.com/three@0.160.1/examples/jsm/controls/PointerLockControls.js";
-        import { SkeletonUtils } from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js";
+        import * as THREE from "https://unpkg.com/three@0.160.1/build/three.module.js?module";
+        import { GLTFLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/GLTFLoader.js?module";
+        import { DRACOLoader } from "https://unpkg.com/three@0.160.1/examples/jsm/loaders/DRACOLoader.js?module";
+        import { PointerLockControls } from "https://unpkg.com/three@0.160.1/examples/jsm/controls/PointerLockControls.js?module";
+        import { SkeletonUtils } from "https://unpkg.com/three@0.160.1/examples/jsm/utils/SkeletonUtils.js?module";
 
         const THREE_VERSION = "0.160.1";
         const THREE_BASE_URL = `https://unpkg.com/three@${THREE_VERSION}`;


### PR DESCRIPTION
## Summary
- append `?module` to the three.js CDN imports so that browser resolves bare specifiers inside the example modules

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_b_68cd02cf8c8483279d66e7c095b66d6c